### PR TITLE
Fix undefined behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ static const int kPageSize = 4096;
 class AIORequest {
  public:
   int* buffer_;
+  struct iocb iocb_;
 
   virtual void Complete(int res) = 0;
 
@@ -237,9 +238,9 @@ class AIOAdder : public Adder {
 
   void SubmitWrite() {
     LOG(INFO) << "Submitting a write to " << counter_;
-    struct iocb iocb;
-    struct iocb* iocbs = &iocb;
     AIORequest *req = new AIOWriteRequest(counter_);
+    struct iocb& iocb = req->iocb_;
+    struct iocb* iocbs = &iocb;
     io_prep_pwrite(&iocb, fd_, req->buffer_, kPageSize, counter_ * kPageSize);
     iocb.data = req;
     int res = io_submit(ioctx_, 1, &iocbs);
@@ -257,9 +258,9 @@ class AIOAdder : public Adder {
 
   void SubmitRead() {
     LOG(INFO) << "Submitting a read from " << counter_;
-    struct iocb iocb;
-    struct iocb* iocbs = &iocb;
     AIORequest *req = new AIOReadRequest(this);
+    struct iocb& iocb = req->iocb_;
+    struct iocb* iocbs = &iocb;
     io_prep_pread(&iocb, fd_, req->buffer_, kPageSize, counter_ * kPageSize);
     iocb.data = req;
     int res = io_submit(ioctx_, 1, &iocbs);


### PR DESCRIPTION
The original version used IO control blocks from the stack, which will
be overwritten after the function has returned. However, IO control
blocks should live until the IO has completed.